### PR TITLE
Fix #29 : compile error after #26.

### DIFF
--- a/src/main/LaunchInterceptor.java
+++ b/src/main/LaunchInterceptor.java
@@ -78,9 +78,9 @@ public class LaunchInterceptor {
         return true;
     }
 
-    boolean lic0() {
+    public boolean lic0() {
         for (int i = 1; i < numPoints; i++) {
-            if (points[i - 1].distanceTo(points[i]) > LENGTH1) {
+            if (points[i - 1].distanceTo(points[i]) > parameters.LENGTH1) {
                 return true;
             }
         }


### PR DESCRIPTION
LENGTH1 should have referenced the field with the same name in
parameters, this patch fixes that. It also changes the method access
modifier to allow for later testing (package-private -> public).